### PR TITLE
Switch from deprecated ErrorT to ExceptT

### DIFF
--- a/extensions/hs-src/Language/Scheme/Plugins/JSON.hs
+++ b/extensions/hs-src/Language/Scheme/Plugins/JSON.hs
@@ -12,7 +12,7 @@ be called directly from husk using the FFI.
 
 module Language.Scheme.Plugins.JSON where 
 
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Array
 import Data.Ratio
 import Text.JSON

--- a/hs-src/Compiler/huskc.hs
+++ b/hs-src/Compiler/huskc.hs
@@ -16,7 +16,7 @@ import Language.Scheme.Compiler.Types
 import qualified Language.Scheme.Core
 import Language.Scheme.Types     -- Scheme data types
 import Language.Scheme.Variables -- Scheme variable operations
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Maybe (fromMaybe)
 import System.Console.GetOpt
 import System.FilePath (dropExtension)

--- a/hs-src/Interpreter/shell.hs
+++ b/hs-src/Interpreter/shell.hs
@@ -16,7 +16,7 @@ import qualified Language.Scheme.Core as LSC -- Scheme Interpreter
 import Language.Scheme.Types                 -- Scheme data types
 import qualified Language.Scheme.Util as LSU (countAllLetters, countLetters, strip)
 import qualified Language.Scheme.Variables as LSV -- Scheme variable operations
-import Control.Monad.Error
+import Control.Monad.Except
 import qualified Data.Char as DC
 import qualified Data.List as DL
 import Data.Maybe (fromMaybe)

--- a/hs-src/Language/Scheme/Compiler.hs
+++ b/hs-src/Language/Scheme/Compiler.hs
@@ -58,7 +58,7 @@ import qualified Language.Scheme.Macro
 import Language.Scheme.Primitives
 import Language.Scheme.Types
 import Language.Scheme.Variables
-import Control.Monad.Error
+import Control.Monad.Except
 import qualified Data.List
 import Data.Maybe (fromMaybe)
 
@@ -1089,8 +1089,8 @@ compileSpecialForm _ formCode copts = do
 compileSpecialFormBody :: Env
                        -> LispVal
                        -> CompOpts
-                       -> (Maybe String -> ErrorT LispError IO [HaskAST])
-                       -> ErrorT LispError IO [HaskAST]
+                       -> (Maybe String -> ExceptT LispError IO [HaskAST])
+                       -> ExceptT LispError IO [HaskAST]
 compileSpecialFormBody env 
                        ast@(List (Atom fnc : _)) 
                        copts@(CompileOptions _ _ _ nextFunc) 

--- a/hs-src/Language/Scheme/Compiler/Libraries.hs
+++ b/hs-src/Language/Scheme/Compiler/Libraries.hs
@@ -22,7 +22,7 @@ import qualified Language.Scheme.Core as LSC
 import Language.Scheme.Primitives
 import Language.Scheme.Types
 import Language.Scheme.Variables
-import Control.Monad.Error
+import Control.Monad.Except
 
 -- |Import all given modules and generate code for them
 importAll 
@@ -59,7 +59,7 @@ _importAll :: Env
            -> LispVal
            -> CompLibOpts
            -> CompOpts
-           -> ErrorT LispError IO [HaskAST]
+           -> ExceptT LispError IO [HaskAST]
 _importAll env metaEnv m lopts copts = do
     -- Resolve import
     resolved <- LSC.evalLisp metaEnv $ 
@@ -78,7 +78,7 @@ importModule :: Env
              -> [LispVal]
              -> CompLibOpts
              -> CompOpts
-             -> ErrorT LispError IO [HaskAST]
+             -> ExceptT LispError IO [HaskAST]
 importModule env metaEnv moduleName imports lopts 
              (CompileOptions thisFunc _ _ lastFunc) = do
     Atom symImport <- _gensym "importFnc"
@@ -210,7 +210,7 @@ compileModule :: Env
               -> LispVal
               -> CompLibOpts
               -> CompOpts
-              -> ErrorT LispError IO [HaskAST]
+              -> ExceptT LispError IO [HaskAST]
 compileModule env metaEnv name _mod lopts 
               (CompileOptions thisFunc _ _ lastFunc) = do
     -- TODO: set mod meta-data to avoid cyclic references
@@ -263,7 +263,7 @@ cmpSubMod :: Env
           -> LispVal
           -> CompLibOpts
           -> CompOpts
-          -> ErrorT LispError IO [HaskAST]
+          -> ExceptT LispError IO [HaskAST]
 cmpSubMod env metaEnv (List ((List (Atom "import-immutable" : modules)) : ls)) 
     lopts copts = do
     -- Punt on this for now, although the meta-lang does the same thing
@@ -293,7 +293,7 @@ cmpModExpr :: Env
            -> LispVal
            -> CompLibOpts
            -> CompOpts
-           -> ErrorT LispError IO [HaskAST]
+           -> ExceptT LispError IO [HaskAST]
 cmpModExpr env metaEnv name (List ((List (Atom "include" : files)) : ls)) 
     lopts@(CompileLibraryOptions _ compileLisp)
     (CompileOptions thisFunc _ _ lastFunc) = do
@@ -350,10 +350,10 @@ includeAll :: forall t t1 t2 t3.
               -> t3
               -> [t2]
               -> (t3
-                  -> t2 -> String -> Maybe String -> ErrorT LispError IO [HaskAST])
+                  -> t2 -> String -> Maybe String -> ExceptT LispError IO [HaskAST])
               -> t1
               -> CompOpts
-              -> ErrorT LispError IO [HaskAST]
+              -> ExceptT LispError IO [HaskAST]
 includeAll _ dir [file] include _ --lopts
           (CompileOptions thisFunc _ _ lastFunc) = do
     include dir file thisFunc lastFunc

--- a/hs-src/Language/Scheme/Environments.hs
+++ b/hs-src/Language/Scheme/Environments.hs
@@ -20,7 +20,7 @@ import Language.Scheme.Numerical
 import Language.Scheme.Primitives
 import Language.Scheme.Types
 import Language.Scheme.Variables
-import Control.Monad.Error
+import Control.Monad.Except
 import qualified Data.Char
 import System.IO
 

--- a/hs-src/Language/Scheme/Libraries.hs
+++ b/hs-src/Language/Scheme/Libraries.hs
@@ -19,7 +19,7 @@ module Language.Scheme.Libraries
     ) where
 import Language.Scheme.Types
 import Language.Scheme.Variables
-import Control.Monad.Error
+import Control.Monad.Except
 
 -- |Get the full path to a module file
 findModuleFile 

--- a/hs-src/Language/Scheme/Macro.hs
+++ b/hs-src/Language/Scheme/Macro.hs
@@ -52,7 +52,7 @@ import Language.Scheme.Variables
 import Language.Scheme.Macro.ExplicitRenaming
 import qualified Language.Scheme.Macro.Matches as Matches
 import Language.Scheme.Primitives (_gensym)
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Array
 -- import Debug.Trace -- Only req'd to support trace, can be disabled at any time...
 
@@ -138,7 +138,7 @@ macroEval env lisp apply = _macroEval env lisp apply
 _macroEval :: Env
            -> LispVal
            -> (LispVal -> LispVal -> [LispVal] -> IOThrowsError LispVal)
-           -> ErrorT LispError IO LispVal
+           -> ExceptT LispError IO LispVal
 _macroEval env lisp@(List (Atom x : _)) apply = do
   -- Note: If there is a procedure of the same name it will be shadowed by the macro.
   var <- getNamespacedVar' env macroNamespace x

--- a/hs-src/Language/Scheme/Macro/ExplicitRenaming.hs
+++ b/hs-src/Language/Scheme/Macro/ExplicitRenaming.hs
@@ -27,7 +27,7 @@ module Language.Scheme.Macro.ExplicitRenaming
 import Language.Scheme.Types
 import Language.Scheme.Variables
 import Language.Scheme.Primitives (_gensym)
-import Control.Monad.Error
+import Control.Monad.Except
 -- import Debug.Trace
 
 -- |Handle an explicit renaming macro

--- a/hs-src/Language/Scheme/Numerical.hs
+++ b/hs-src/Language/Scheme/Numerical.hs
@@ -71,7 +71,7 @@ module Language.Scheme.Numerical (
 ) where
 import Language.Scheme.Types
 
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Char hiding (isNumber)
 import Data.Complex
 import Data.Fixed

--- a/hs-src/Language/Scheme/Parser.hs
+++ b/hs-src/Language/Scheme/Parser.hs
@@ -46,7 +46,7 @@ module Language.Scheme.Parser
     , parseUnquoteSpliced 
     ) where
 import Language.Scheme.Types
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Array
 import qualified Data.ByteString as BS
 import qualified Data.Char as DC

--- a/hs-src/Language/Scheme/Plugins/CPUTime.hs
+++ b/hs-src/Language/Scheme/Plugins/CPUTime.hs
@@ -20,7 +20,7 @@ module Language.Scheme.Plugins.CPUTime (get, precision) where
 
 import Language.Scheme.Types
 import System.CPUTime
-import Control.Monad.Error
+import Control.Monad.Except
 
 -- |Wrapper for CPUTime.getCPUTime
 get :: [LispVal] -> IOThrowsError LispVal

--- a/hs-src/Language/Scheme/Primitives.hs
+++ b/hs-src/Language/Scheme/Primitives.hs
@@ -161,7 +161,7 @@ import Language.Scheme.Parser
 import Language.Scheme.Types
 import Language.Scheme.Variables
 --import qualified Control.Exception
-import Control.Monad.Error
+import Control.Monad.Except
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as BSU
 import Data.Char hiding (isSymbol)
@@ -559,7 +559,7 @@ readBuffer args _ = if length args == 2
              (MonadIO m, MonadError LispError m) =>
              (Handle -> LispVal -> IO a) -> [LispVal] -> m LispVal -}
 writeProc :: (Handle -> LispVal -> IO a)
-          -> [LispVal] -> ErrorT LispError IO LispVal
+          -> [LispVal] -> ExceptT LispError IO LispVal
 writeProc func [obj] = do
     dobj <- recDerefPtrs obj -- Last opportunity to do this before writing
     writeProc func [dobj, Port stdout Nothing]

--- a/hs-src/Language/Scheme/Types.hs
+++ b/hs-src/Language/Scheme/Types.hs
@@ -96,7 +96,7 @@ module Language.Scheme.Types
     , validateFuncParams
     )
  where
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Complex
 import Data.Array
 import qualified Data.ByteString as BS
@@ -165,9 +165,6 @@ showError (Default message) = "Error: " ++ message
 showError (ErrorWithCallHist err stack) = showCallHistory (show err) stack
 
 instance Show LispError where show = showError
-instance Error LispError where
-  noMsg = Default "An error has occurred"
-  strMsg = Default
 
 -- |Display call history for an error
 showCallHistory :: String -> [LispVal] -> String
@@ -183,7 +180,7 @@ showCallHistory message hist = do
 type ThrowsError = Either LispError
 
 -- |Container used to provide error handling in the IO monad
-type IOThrowsError = ErrorT LispError IO
+type IOThrowsError = ExceptT LispError IO
 
 -- |Lift a ThrowsError into the IO monad
 liftThrows :: ThrowsError a -> IOThrowsError a

--- a/hs-src/Language/Scheme/Variables.hs
+++ b/hs-src/Language/Scheme/Variables.hs
@@ -54,7 +54,7 @@ module Language.Scheme.Variables
     , recDerefToFnc
     ) where
 import Language.Scheme.Types
-import Control.Monad.Error
+import Control.Monad.Except
 import Data.Array
 import Data.IORef
 import qualified Data.Map

--- a/husk-scheme.cabal
+++ b/husk-scheme.cabal
@@ -116,6 +116,7 @@ Executable         huski
   Extensions:      ExistentialQuantification
   Main-is:         shell.hs
   Hs-Source-Dirs:  hs-src/Interpreter
+  Other-Modules:   Paths_husk_scheme
 
 Executable huskc
   Build-Depends: husk-scheme, base >= 2.0 && < 5, array, containers, haskeline, transformers, mtl, parsec, directory, ghc-paths, process, filepath
@@ -129,3 +130,4 @@ Executable huskc
   Extensions:      ExistentialQuantification
   Main-is: huskc.hs
   Hs-Source-Dirs: hs-src/Compiler
+  Other-Modules:   Paths_husk_scheme


### PR DESCRIPTION
Hi Justin,

Thanks for the great project. I'm using husk-scheme to preprocess scheme code before I run static analyses on it (https://github.com/svenkeidel/sturdy/tree/scheme).

That aside, I updated the from the deprecated `ErrorT` transformer to the `ExceptT` transformer. Now the code compiles without any warnings. I tested this together with both commits in https://github.com/justinethier/husk-scheme/pull/212, because otherwise the code won't compile for me. Let me know what you think.

Regards,
Sven