### PR TITLE
Minimal change to compile with ghc-8.8 and ghc-8.10

### DIFF
--- a/hs-src/Language/Scheme/Parser.hs
+++ b/hs-src/Language/Scheme/Parser.hs
@@ -319,7 +319,7 @@ parseEscapedChar = do
     _ -> return c
 
 -- |Parse a hexidecimal scalar
-parseHexScalar :: Monad m => String -> m Char
+parseHexScalar :: String -> GenParser Char st Char
 parseHexScalar num = do
     let ns = Numeric.readHex num
     case ns of


### PR DESCRIPTION
This is another MonadFail fix; instead of explicitly adding any code to deal
with the MonadFail transition, concretizing the type of the Monad in
`parseHexScalar` is sufficient (since the `GenParser` implementation of `fail`
is the same).