### PR TITLE
Add support for GHC 9.12

### DIFF
--- a/examples/ffi/Opaque.hs
+++ b/examples/ffi/Opaque.hs
@@ -29,15 +29,15 @@ unpackSet :: LispVal -> ThrowsError (S.Set String)
 unpackSet = fromOpaque
 
 primSingleton :: [LispVal] -> ThrowsError LispVal
-primSingleton [e] = liftM (toOpaque . S.singleton) (unpackStr e)
+primSingleton [e] = fmap (toOpaque . S.singleton) (unpackStr e)
 primSingleton badArgs = throwError $ NumArgs (Just 1) badArgs
 
 primElem :: [LispVal] -> ThrowsError LispVal
-primElem [e, s] = liftM Bool $ liftM2 (S.member) (unpackStr e) (unpackSet s)
+primElem [e, s] = fmap Bool $ liftM2 (S.member) (unpackStr e) (unpackSet s)
 primElem badArgs = throwError $ NumArgs (Just 2) badArgs
 
 primUnion :: [LispVal] -> ThrowsError LispVal
-primUnion = liftM (toOpaque . S.unions) . mapM unpackSet
+primUnion = fmap (toOpaque . S.unions) . mapM unpackSet
 
 setBindings :: [(String, LispVal)]
 setBindings = [

--- a/hs-src/Compiler/huskc.hs
+++ b/hs-src/Compiler/huskc.hs
@@ -10,6 +10,7 @@ A front-end for the husk compiler
 -}
 
 module Main where
+import Control.Monad.IO.Class (liftIO)
 import Paths_husk_scheme
 import Language.Scheme.Compiler
 import Language.Scheme.Compiler.Types

--- a/hs-src/Compiler/huskc.hs
+++ b/hs-src/Compiler/huskc.hs
@@ -146,7 +146,7 @@ process inFile outHaskell outExec libs dynamic extraArgs langrev debugOpt = do
                      then Just stdlib
                      else Nothing
 
-  result <- (Language.Scheme.Core.runIOThrows $ liftM show $ compileSchemeFile env stdlibArg srfi55 inFile outHaskell langrev debugOpt)
+  result <- (Language.Scheme.Core.runIOThrows $ fmap show $ compileSchemeFile env stdlibArg srfi55 inFile outHaskell langrev debugOpt)
   case result of
    Just errMsg -> putStrLn errMsg
    _ -> compileHaskellFile outHaskell outExec dynamic extraArgs

--- a/hs-src/Interpreter/shell.hs
+++ b/hs-src/Interpreter/shell.hs
@@ -12,6 +12,7 @@ allows execution of stand-alone files containing Scheme code.
 -}
 
 module Main where
+import Control.Monad.IO.Class (liftIO)
 import qualified Language.Scheme.Core as LSC -- Scheme Interpreter
 import Language.Scheme.Types                 -- Scheme data types
 import qualified Language.Scheme.Util as LSU (countAllLetters, countLetters, strip)

--- a/hs-src/Interpreter/shell.hs
+++ b/hs-src/Interpreter/shell.hs
@@ -12,6 +12,7 @@ allows execution of stand-alone files containing Scheme code.
 -}
 
 module Main where
+import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import qualified Language.Scheme.Core as LSC -- Scheme Interpreter
 import Language.Scheme.Types                 -- Scheme data types

--- a/hs-src/Interpreter/shell.hs
+++ b/hs-src/Interpreter/shell.hs
@@ -108,7 +108,7 @@ runOne initEnv args interactive = do
                           [((LSV.varNamespace, "args"),
                            List $ map String $ drop 1 args)]
 
-  result <- (LSC.runIOThrows $ liftM show $ 
+  result <- (LSC.runIOThrows $ fmap show $ 
              LSC.evalLisp env (List [Atom "load", String (head args)]))
   _ <- case result of
     Just errMsg -> putStrLn errMsg
@@ -117,7 +117,7 @@ runOne initEnv args interactive = do
       alreadyDefined <- liftIO $ LSV.isBound env "main"
       let argv = List $ map String args
       when alreadyDefined (do 
-        mainResult <- (LSC.runIOThrows $ liftM show $ 
+        mainResult <- (LSC.runIOThrows $ fmap show $ 
                        LSC.evalLisp env (List [Atom "main", List [Atom "quote", argv]]))
         case mainResult of
           Just errMsg -> putStrLn errMsg

--- a/hs-src/Language/Scheme/Compiler.hs
+++ b/hs-src/Language/Scheme/Compiler.hs
@@ -50,6 +50,7 @@ module Language.Scheme.Compiler
     , mfunc
     )
 where 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Compiler.Libraries as LSCL
 import Language.Scheme.Compiler.Types
 import qualified Language.Scheme.Core as LSC 

--- a/hs-src/Language/Scheme/Compiler/Libraries.hs
+++ b/hs-src/Language/Scheme/Compiler/Libraries.hs
@@ -16,6 +16,7 @@ module Language.Scheme.Compiler.Libraries
       importAll
     )
 where 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Compiler.Types
 import qualified Language.Scheme.Core as LSC 
     (evalLisp, findFileOrLib, meval, nullEnvWithImport)

--- a/hs-src/Language/Scheme/Compiler/Types.hs
+++ b/hs-src/Language/Scheme/Compiler/Types.hs
@@ -215,7 +215,7 @@ headerImports = [
  , "Language.Scheme.Primitives "
  , "Language.Scheme.Types     -- Scheme data types "
  , "Language.Scheme.Variables -- Scheme variable operations "
- , "Control.Monad.Error "
+ , "Control.Monad.Except "
  , "Control.Monad.IO.Class "
  , "Data.Array "
  , " qualified Data.ByteString as BS "

--- a/hs-src/Language/Scheme/Compiler/Types.hs
+++ b/hs-src/Language/Scheme/Compiler/Types.hs
@@ -34,6 +34,7 @@ module Language.Scheme.Compiler.Types
     , headerImports
     )
 where 
+import Control.Monad.IO.Class (liftIO)
 import qualified Language.Scheme.Core as LSC (version) 
 import Language.Scheme.Types
 import qualified Language.Scheme.Util (escapeBackslashes)

--- a/hs-src/Language/Scheme/Compiler/Types.hs
+++ b/hs-src/Language/Scheme/Compiler/Types.hs
@@ -275,7 +275,7 @@ header filepath useCompiledLibs langRev = do
     , "main :: IO () "
     , "main = do "
     , "  env <- " ++ env ++ " "
-    , "  result <- (runIOThrows $ liftM show $ hsInit env (makeNullContinuation env) (Nil \"\") Nothing) "
+    , "  result <- (runIOThrows $ fmap show $ hsInit env (makeNullContinuation env) (Nil \"\") Nothing) "
     , "  case result of "
     , "    Just errMsg -> putStrLn errMsg "
     , "    _ -> return () "

--- a/hs-src/Language/Scheme/Compiler/Types.hs
+++ b/hs-src/Language/Scheme/Compiler/Types.hs
@@ -12,7 +12,7 @@ Portability : portable
 This module contains data types used by the compiler.
 -}
 
-module Language.Scheme.Compiler.Types 
+module Language.Scheme.Compiler.Types
     (
     -- * Data types
       CompOpts (..)
@@ -22,9 +22,9 @@ module Language.Scheme.Compiler.Types
     -- * Utility functions
     , ast2Str
     , asts2Str
-    , createAstFunc 
-    , createAstCont 
-    , joinL 
+    , createAstFunc
+    , createAstCont
+    , joinL
     , moduleRuntimeVar
     , showValAST
     -- * Headers appended to output file
@@ -33,9 +33,9 @@ module Language.Scheme.Compiler.Types
     , headerModule
     , headerImports
     )
-where 
+where
 import Control.Monad.IO.Class (liftIO)
-import qualified Language.Scheme.Core as LSC (version) 
+import qualified Language.Scheme.Core as LSC (version)
 import Language.Scheme.Types
 import qualified Language.Scheme.Util (escapeBackslashes)
 import qualified Data.Array
@@ -46,20 +46,20 @@ import qualified Data.Map
 import qualified Data.Ratio as DR
 
 -- |A type to store options passed to compile.
---  Eventually all of this might be able to be 
+--  Eventually all of this might be able to be
 --  integrated into a Compile monad.
 data CompOpts = CompileOptions {
-    coptsThisFunc :: String,        
+    coptsThisFunc :: String,
     -- ^Immediate name to use when creating a compiled function.
     --  Presumably there is other code that is expecting
     --  to call into it.
 
     coptsThisFuncUseValue :: Bool,
     -- ^Whether to include the /value/ parameter in the current function
-    
+
     coptsThisFuncUseArgs :: Bool,
     -- ^Whether to include the /args/ parameter in the current function
-    
+
     coptsNextFunc :: Maybe String
     -- ^The name to use for the next function after the current
     --  compiler recursion is finished. For example, after compiling
@@ -73,9 +73,9 @@ defaultCompileOptions thisFunc = CompileOptions thisFunc False False Nothing
 
 -- |Options passed to the compiler library module
 data CompLibOpts = CompileLibraryOptions {
-    compBlock :: String -> Maybe String -> Env 
+    compBlock :: String -> Maybe String -> Env
               -> [HaskAST] -> [LispVal] -> IOThrowsError [HaskAST],
-    compLisp :: Env -> String -> String -> Maybe String 
+    compLisp :: Env -> String -> String -> Maybe String
               -> IOThrowsError [HaskAST]
     }
 
@@ -84,7 +84,7 @@ moduleRuntimeVar :: String
 moduleRuntimeVar = " modules "
 
 -- |Create code for a function
-createAstFunc 
+createAstFunc
   :: CompOpts  -- ^ Compilation options
   -> [HaskAST] -- ^ Body of the function
   -> HaskAST -- ^ Complete function code
@@ -94,7 +94,7 @@ createAstFunc (CompileOptions thisFunc useVal useArgs _) funcBody = do
   AstFunction thisFunc (" env cont " ++ val ++ " " ++ args ++ " ") funcBody
 
 -- |Create code for a continutation
-createAstCont 
+createAstCont
   :: CompOpts -- ^ Compilation options
   -> String -- ^ Value to send to the continuation
   -> String -- ^ Extra leading indentation (or blank string if none)
@@ -113,7 +113,7 @@ data HaskAST = AstAssignM String HaskAST
 --                 astfType :: String,
                  astfArgs :: String,
                  astfCode :: [HaskAST]
-                } 
+                }
  | AstValue String
  | AstRef String
  | AstContinuation {astcNext :: String,
@@ -130,36 +130,36 @@ showValAST (AstFunction name args code) = do
 #ifdef UseDebug
   let appendArg arg = do
         if Data.List.isInfixOf arg args
-           then " ++ \" \" ++ " ++ (show arg) ++ 
-                " ++ \" [\" ++ (show " ++ arg ++ ")" ++ 
+           then " ++ \" \" ++ " ++ (show arg) ++
+                " ++ \" [\" ++ (show " ++ arg ++ ")" ++
                 " ++ \"] \""
            else ""
-  let fdebug = "\n  _ <- liftIO $ (trace (\"" ++ 
-               name ++ "\"" ++ 
-               (appendArg "value") ++ 
-               (appendArg "args") ++ 
+  let fdebug = "\n  _ <- liftIO $ (trace (\"" ++
+               name ++ "\"" ++
+               (appendArg "value") ++
+               (appendArg "args") ++
                ") getCPUTime)"
-  typeSig ++ fheader ++ fdebug ++ fbody 
+  typeSig ++ fheader ++ fdebug ++ fbody
 #else
-  typeSig ++ fheader ++ fbody 
+  typeSig ++ fheader ++ fbody
 #endif
 showValAST (AstValue v) = v
 showValAST (AstRef v) = v
 showValAST (AstContinuation nextFunc args) =
-    "  continueEval env (makeCPSWArgs env cont " ++ 
+    "  continueEval env (makeCPSWArgs env cont " ++
        nextFunc ++ " " ++ args ++ ") (Nil \"\") Nothing "
 
 instance Show HaskAST where show = showValAST
 
 -- |A utility function to join list members together
-joinL 
+joinL
   :: forall a. [[a]] -- ^ Original list-of-lists
-  -> [a] -- ^ Separator 
+  -> [a] -- ^ Separator
   -> [a] -- ^ Joined list
 joinL ls sep = Data.List.intercalate sep ls
 
 -- |Convert abstract syntax tree to a string
-ast2Str :: LispVal -> String 
+ast2Str :: LispVal -> String
 ast2Str (String s) = "String " ++ show s
 ast2Str (Char c) = "Char " ++ show c
 ast2Str (Atom a) = "Atom " ++ show a
@@ -170,7 +170,7 @@ ast2Str (Float f) = "Float (" ++ show f ++ ")"
 ast2Str (Bool True) = "Bool True"
 ast2Str (Bool False) = "Bool False"
 ast2Str (HashTable ht) = do
- let ls = Data.Map.toList ht 
+ let ls = Data.Map.toList ht
      conv (a, b) = "(" ++ ast2Str a ++ "," ++ ast2Str b ++ ")"
  "HashTable $ Data.Map.fromList $ [" ++ joinL (map conv ls) "," ++ "]"
 ast2Str (Vector v) = do
@@ -181,7 +181,7 @@ ast2Str (ByteVector bv) = do
   let ls = BS.unpack bv
   "ByteVector ( BS.pack " ++ "[" ++ joinL (map show ls) "," ++ "])"
 ast2Str (List ls) = "List [" ++ joinL (map ast2Str ls) "," ++ "]"
-ast2Str (DottedList ls l) = 
+ast2Str (DottedList ls l) =
   "DottedList [" ++ joinL (map ast2Str ls) "," ++ "] $ " ++ ast2Str l
 ast2Str l = show l -- Error?
 
@@ -216,6 +216,7 @@ headerImports = [
  , "Language.Scheme.Types     -- Scheme data types "
  , "Language.Scheme.Variables -- Scheme variable operations "
  , "Control.Monad.Error "
+ , "Control.Monad.IO.Class "
  , "Data.Array "
  , " qualified Data.ByteString as BS "
  , "Data.Complex "
@@ -229,7 +230,7 @@ headerImports = [
 #endif
  ]
 
--- |Block of code used in the header of a Haskell program 
+-- |Block of code used in the header of a Haskell program
 --  generated by the compiler.
 header :: String -> Bool -> String -> [String]
 header filepath useCompiledLibs langRev = do
@@ -238,7 +239,7 @@ header filepath useCompiledLibs langRev = do
             else case langRev of
                    "7" -> "r7rsEnv"
                    _ -> "r5rsEnv"
-      initSrfi55 = 
+      initSrfi55 =
         case langRev of
           "7" -> []
           _ -> [ "exec55_3 env cont _ _ = do "
@@ -247,8 +248,8 @@ header filepath useCompiledLibs langRev = do
   [ " "
     , " "
     , "-- |Get variable at runtime "
-    , "getRTVar env var = do " 
-    , "  v <- getVar env var " 
+    , "getRTVar env var = do "
+    , "  v <- getVar env var "
     , "  return $ case v of "
     , "    List _ -> Pointer var env "
     , "    DottedList _ _ -> Pointer var env "
@@ -270,7 +271,7 @@ header filepath useCompiledLibs langRev = do
     , "getDataFileName' :: FilePath -> IO FilePath "
     , "getDataFileName' name = return $ \"" ++ (Language.Scheme.Util.escapeBackslashes filepath) ++ "\" ++ name "
     , " "]
-    ++ initSrfi55 ++ 
+    ++ initSrfi55 ++
     [ " "
     , "main :: IO () "
     , "main = do "

--- a/hs-src/Language/Scheme/Core.hs
+++ b/hs-src/Language/Scheme/Core.hs
@@ -50,6 +50,7 @@ module Language.Scheme.Core
     -- * Internal use only
     , meval
     ) where
+import Control.Monad.IO.Class (liftIO)
 import qualified Paths_husk_scheme as PHS (getDataFileName, version)
 #ifdef UseFfi
 import qualified Language.Scheme.FFI

--- a/hs-src/Language/Scheme/Core.hs
+++ b/hs-src/Language/Scheme/Core.hs
@@ -222,7 +222,7 @@ evalString env "(* 3 9)"
 -}
 evalString :: Env -> String -> IO String
 evalString env expr = do
-  runIOThrowsREPL $ liftM show $ liftThrows (readExpr expr) >>= evalLisp env
+  runIOThrowsREPL $ fmap show $ liftThrows (readExpr expr) >>= evalLisp env
 
 -- |Evaluate a string and print results to console
 evalAndPrint :: Env -> String -> IO ()

--- a/hs-src/Language/Scheme/Environments.hs
+++ b/hs-src/Language/Scheme/Environments.hs
@@ -15,6 +15,7 @@ module Language.Scheme.Environments
       primitives
     , ioPrimitives
     ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Libraries
 import Language.Scheme.Numerical
 import Language.Scheme.Primitives

--- a/hs-src/Language/Scheme/FFI.hs
+++ b/hs-src/Language/Scheme/FFI.hs
@@ -16,11 +16,18 @@ module Language.Scheme.FFI (evalfuncLoadFFI) where
 import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Language.Scheme.Variables
-import Control.Monad.Error
+import Control.Monad.Except
 
 import qualified GHC
 import qualified GHC.Paths (libdir)
+import qualified GHC.Unit.Types
+#if __GLASGOW_HASKELL__ < 900
 import qualified DynFlags
+#elif __GLASGOW_HASKELL__ < 980
+import qualified GHC.Driver.Session as DynFlags
+#else
+import qualified GHC.Driver.DynFlags as DynFlags
+#endif
 import qualified Unsafe.Coerce (unsafeCoerce)
 
 -- |Load a Haskell function into husk using the GHC API.
@@ -37,7 +44,7 @@ evalfuncLoadFFI :: [LispVal] -> IOThrowsError LispVal
  -
  -
  - TODO: pass a list of functions to import. Need to make sure this is done in an efficient way
- - (IE, result as a list that can be processed) 
+ - (IE, result as a list that can be processed)
  -}
 evalfuncLoadFFI [(Continuation env _ _ _ _), String targetSrcFile,
                                                   String moduleName,
@@ -52,7 +59,7 @@ evalfuncLoadFFI [(Continuation env _ _ _ _), String targetSrcFile,
 {- TODO: migrate duplicate code into helper functions to drive everything
 FUTURE: should be able to load multiple functions in one shot (?). -}
 --
-    target <- GHC.guessTarget targetSrcFile Nothing
+    target <- guessTarget targetSrcFile Nothing Nothing
     GHC.addTarget target
     r <- GHC.load GHC.LoadAllTargets
     case r of
@@ -64,17 +71,17 @@ FUTURE: should be able to load multiple functions in one shot (?). -}
 #elif __GLASGOW_HASKELL__ == 702
     -- Fix from dflemstr:
     -- http://stackoverflow.com/questions/9198140/ghc-api-how-to-dynamically-load-haskell-code-from-a-compiled-module-using-ghc
-           GHC.setContext [] 
+           GHC.setContext []
              -- import qualified Module
              [ (GHC.simpleImportDecl . GHC.mkModuleName $ moduleName)
-               {GHC.ideclQualified = True}
+               {GHC.ideclQualified = importDeclQualified}
              ]
 #elif __GLASGOW_HASKELL__ >= 704
-           GHC.setContext  
+           GHC.setContext
              -- import qualified Module
-             [ GHC.IIDecl $ 
+             [ GHC.IIDecl $
                (GHC.simpleImportDecl . GHC.mkModuleName $ moduleName)
-               {GHC.ideclQualified = True}
+               {GHC.ideclQualified = importDeclQualified}
              ]
 #else
            GHC.setContext [] [(m, Nothing)]
@@ -94,17 +101,17 @@ evalfuncLoadFFI [(Continuation env _ _ _ _), String moduleName, String externalF
 #elif __GLASGOW_HASKELL__ == 702
     -- Fix from dflemstr:
     -- http://stackoverflow.com/questions/9198140/ghc-api-how-to-dynamically-load-haskell-code-from-a-compiled-module-using-ghc
-    GHC.setContext [] 
+    GHC.setContext []
       -- import qualified Module
       [ (GHC.simpleImportDecl . GHC.mkModuleName $ moduleName)
-        {GHC.ideclQualified = True}
+        {GHC.ideclQualified = importDeclQualified}
       ]
 #elif __GLASGOW_HASKELL__ >= 704
-    GHC.setContext  
+    GHC.setContext
       -- import qualified Module
-      [ GHC.IIDecl $ 
+      [ GHC.IIDecl $
         (GHC.simpleImportDecl . GHC.mkModuleName $ moduleName)
-        {GHC.ideclQualified = True}
+        {GHC.ideclQualified = importDeclQualified}
       ]
 #else
     GHC.setContext [] [(m, Nothing)]
@@ -120,10 +127,26 @@ defaultRunGhc =
 #if __GLASGOW_HASKELL__ <= 700
   -- Old syntax for GHC 7.0.x and lower
   GHC.defaultErrorHandler DynFlags.defaultDynFlags . GHC.runGhc (Just GHC.Paths.libdir)
-#elif __GLASGOW_HASKELL__ < 706 
+#elif __GLASGOW_HASKELL__ < 706
   -- New syntax in GHC 7.2
   GHC.defaultErrorHandler DynFlags.defaultLogAction . GHC.runGhc (Just GHC.Paths.libdir)
 #else
   -- New syntax in GHC 7.6
   GHC.defaultErrorHandler DynFlags.defaultFatalMessager DynFlags.defaultFlushOut . GHC.runGhc (Just GHC.Paths.libdir)
+#endif
+
+#if __GLASGOW_HASKELL__ < 810
+importDeclQualified :: Bool
+importDeclQualified = True
+#else
+importDeclQualified :: GHC.ImportDeclQualifiedStyle
+importDeclQualified = GHC.QualifiedPre
+#endif
+
+#if __GLASGOW_HASKELL__ < 903
+guessTarget :: GHC.GhcMonad m => String -> a -> Maybe GHC.Phase -> m GHC.Target
+guessTarget a _ b = GHC.guessTarget a b
+#else
+guessTarget :: GHC.GhcMonad m => String -> Maybe GHC.Unit.Types.UnitId -> Maybe GHC.Phase -> m GHC.Target
+guessTarget a b c = GHC.guessTarget a b c
 #endif

--- a/hs-src/Language/Scheme/FFI.hs
+++ b/hs-src/Language/Scheme/FFI.hs
@@ -13,6 +13,7 @@ This module contains the foreign function interface.
 -}
 module Language.Scheme.FFI (evalfuncLoadFFI) where
 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Language.Scheme.Variables
 import Control.Monad.Error

--- a/hs-src/Language/Scheme/Libraries.hs
+++ b/hs-src/Language/Scheme/Libraries.hs
@@ -17,6 +17,7 @@ module Language.Scheme.Libraries
       findModuleFile
     , moduleImport
     ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Language.Scheme.Variables
 import Control.Monad.Except

--- a/hs-src/Language/Scheme/Macro.hs
+++ b/hs-src/Language/Scheme/Macro.hs
@@ -47,6 +47,7 @@ module Language.Scheme.Macro
     , loadMacros  
     , getDivertedVars 
     ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Language.Scheme.Variables
 import Language.Scheme.Macro.ExplicitRenaming

--- a/hs-src/Language/Scheme/Macro/ExplicitRenaming.hs
+++ b/hs-src/Language/Scheme/Macro/ExplicitRenaming.hs
@@ -24,6 +24,7 @@ module Language.Scheme.Macro.ExplicitRenaming
     (
       explicitRenamingTransform
     ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Language.Scheme.Variables
 import Language.Scheme.Primitives (_gensym)

--- a/hs-src/Language/Scheme/Parser.hs
+++ b/hs-src/Language/Scheme/Parser.hs
@@ -371,7 +371,7 @@ parseHashTable = do
 
 -- |Parse a list
 parseList :: Parser LispVal
-parseList = liftM List $ sepBy parseExpr whiteSpace
+parseList = fmap List $ sepBy parseExpr whiteSpace
 -- TODO: wanted to use endBy (or a variant) above, but it causes an error such that dotted lists are not parsed
 
 -- |Parse a dotted list (scheme pair)

--- a/hs-src/Language/Scheme/Plugins/CPUTime.hs
+++ b/hs-src/Language/Scheme/Plugins/CPUTime.hs
@@ -18,6 +18,7 @@ call into this module from Scheme code.
 
 module Language.Scheme.Plugins.CPUTime (get, precision) where
 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import System.CPUTime
 import Control.Monad.Except

--- a/hs-src/Language/Scheme/Primitives.hs
+++ b/hs-src/Language/Scheme/Primitives.hs
@@ -156,6 +156,7 @@ module Language.Scheme.Primitives (
 -- , systemRead
 
  ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Numerical
 import Language.Scheme.Parser
 import Language.Scheme.Types

--- a/hs-src/Language/Scheme/Primitives.hs
+++ b/hs-src/Language/Scheme/Primitives.hs
@@ -420,7 +420,7 @@ isOutputPortOpen _ = return $ Bool False
 isInputPort :: [LispVal] -> IOThrowsError LispVal
 isInputPort [p@(Pointer {})] = recDerefPtrs p >>= box >>= isInputPort
 isInputPort [p@(Port _ _)] = 
-  withOpenPort p $ \port -> liftM Bool $ liftIO $ hIsReadable port
+  withOpenPort p $ \port -> fmap Bool $ liftIO $ hIsReadable port
 isInputPort _ = return $ Bool False
 
 -- |Determine if the given objects is an output port
@@ -434,7 +434,7 @@ isInputPort _ = return $ Bool False
 isOutputPort :: [LispVal] -> IOThrowsError LispVal
 isOutputPort [p@(Pointer {})] = recDerefPtrs p >>= box >>= isOutputPort
 isOutputPort [p@(Port _ _)] = 
-    withOpenPort p $ \port -> liftM Bool $ liftIO $ hIsWritable port
+    withOpenPort p $ \port -> fmap Bool $ liftIO $ hIsWritable port
 isOutputPort _ = return $ Bool False
 
 -- |Determine if a character is ready on the port
@@ -447,7 +447,7 @@ isOutputPort _ = return $ Bool False
 --
 isCharReady :: [LispVal] -> IOThrowsError LispVal
 isCharReady [p@(Pointer {})] = recDerefPtrs p >>= box >>= isCharReady
-isCharReady [Port port _] = do --liftM Bool $ liftIO $ hReady port
+isCharReady [Port port _] = do --fmap Bool $ liftIO $ hReady port
     result <- liftIO $ try' (liftIO $ hReady port)
     case result of
         Left e -> if isEOFError e
@@ -681,7 +681,7 @@ deleteFile args@(_ : _) = throwError $ NumArgs (Just 1) args
 --   Returns: String - Actual text read from the file
 --
 readContents :: [LispVal] -> IOThrowsError LispVal
-readContents [String filename] = liftM String $ liftIO $ readFile filename
+readContents [String filename] = fmap String $ liftIO $ readFile filename
 readContents [p@(Pointer _ _)] = recDerefPtrs p >>= box >>= readContents
 readContents [] = throwError $ NumArgs (Just 1) []
 readContents args@(_ : _) = throwError $ NumArgs (Just 1) args
@@ -719,7 +719,7 @@ load filename = do
 --
 readAll :: [LispVal] -> IOThrowsError LispVal
 readAll [p@(Pointer _ _)] = recDerefPtrs p >>= box >>= readAll
-readAll [String filename] = liftM List $ load filename
+readAll [String filename] = fmap List $ load filename
 readAll [] = do -- read from stdin
     input <- liftIO $ getContents
     lisp <- (liftThrows . readExprList) input
@@ -892,7 +892,7 @@ equal [(Vector arg1), (Vector arg2)] = eqvList equal [List $ (elems arg1), List 
 equal [l1@(List _), l2@(List _)] = eqvList equal [l1, l2]
 equal [(DottedList xs x), (DottedList ys y)] = equal [List $ xs ++ [x], List $ ys ++ [y]]
 equal [arg1, arg2] = do
-  primitiveEquals <- liftM or $ mapM (unpackEquals arg1 arg2)
+  primitiveEquals <- fmap or $ mapM (unpackEquals arg1 arg2)
                      [AnyUnpacker unpackNum, AnyUnpacker unpackStr, AnyUnpacker unpackBool]
   eqvEquals <- eqv [arg1, arg2]
   return $ Bool $ (primitiveEquals || let (Bool x) = eqvEquals in x)

--- a/hs-src/Language/Scheme/Variables.hs
+++ b/hs-src/Language/Scheme/Variables.hs
@@ -53,6 +53,7 @@ module Language.Scheme.Variables
     , safeRecDerefPtrs
     , recDerefToFnc
     ) where
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Types
 import Control.Monad.Except
 import Data.Array

--- a/misc/test-bad.hs
+++ b/misc/test-bad.hs
@@ -6,6 +6,7 @@
 --  Version 3.16
 --
 module Main where 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Core  
 import Language.Scheme.Numerical  
 import Language.Scheme.Primitives  

--- a/misc/test-bad.hs
+++ b/misc/test-bad.hs
@@ -50,7 +50,7 @@ exec55_3 env cont _ _ = do
 main :: IO () 
 main = do 
   env <- r5rsEnv 
-  result <- (runIOThrows $ liftM show $ hsInit env (makeNullContinuation env) (Nil "") Nothing) 
+  result <- (runIOThrows $ fmap show $ hsInit env (makeNullContinuation env) (Nil "") Nothing) 
   case result of 
     Just errMsg -> putStrLn errMsg 
     _ -> return () 

--- a/misc/test-good.hs
+++ b/misc/test-good.hs
@@ -6,6 +6,7 @@
 --  Version 3.16
 --
 module Main where 
+import Control.Monad.IO.Class (liftIO)
 import Language.Scheme.Core  
 import Language.Scheme.Numerical  
 import Language.Scheme.Primitives  

--- a/misc/test-good.hs
+++ b/misc/test-good.hs
@@ -50,7 +50,7 @@ exec55_3 env cont _ _ = do
 main :: IO () 
 main = do 
   env <- r5rsEnv 
-  result <- (runIOThrows $ liftM show $ hsInit env (makeNullContinuation env) (Nil "") Nothing) 
+  result <- (runIOThrows $ fmap show $ hsInit env (makeNullContinuation env) (Nil "") Nothing) 
   case result of 
     Just errMsg -> putStrLn errMsg 
     _ -> return () 


### PR DESCRIPTION
The functions `liftIO`, `liftM` and `when` have to be imported explicitly, as mtl 2.3 removed re-exports. Instead of importing `liftM`, I've replaced usages with `fmap`, as that's the more common way to express mapping.

For the FFI module, I took account of API changes in recent versions, while making sure that the code can still compile on older versions.

Tested on GHC versions 8.4.4, 9.6.7 and 9.12.2.